### PR TITLE
fixed typo in docstrings for HHO

### DIFF
--- a/neorl/evolu/hho.py
+++ b/neorl/evolu/hho.py
@@ -41,7 +41,7 @@ class HHO(object):
     :param mode: (str) problem type, either "min" for minimization problem or "max" for maximization
     :param bounds: (dict) input parameter type and lower/upper bounds in dictionary form. Example: ``bounds={'x1': ['int', 1, 4], 'x2': ['float', 0.1, 0.8], 'x3': ['float', 2.2, 6.2]}``
     :param fit: (function) the fitness function 
-    :param nhawks: (int): number of the grey wolves in the group
+    :param nhawks: (int): number of the hawks in the group
     :param int_transform: (str): method of handling int/discrete variables, choose from: ``nearest_int``, ``sigmoid``, ``minmax``.
     :param ncores: (int) number of parallel processors (must be ``<= nhawks``)
     :param seed: (int) random seed for sampling


### PR DESCRIPTION
Went ahead and fixed typo. Did not rebuild docs if that is necessary.

See Issue #9.